### PR TITLE
use v0.3.0 in readme and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,9 @@
 - Change authenticationType default from 'guest' to 'credentials'.
 - Fix issues where report link context menu not always working as expected.
 - Improved handling of report images and fixed an issue where report images would log unauthenticated users in as guest.
+
+## 0.3.0 (November 19, 2019)
+
+- Add support for SAS Visual Analytics 8.5
+- Add support for `<sas-report-page>` custom element for embedding a report page.
+- Additional bug fixes

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ npm install @sassoftware/va-report-components
 
 Accessing the `va-report-components` library from a CDN is easy. It does not require installation or
 hosting of the library code and assets. There are several public options for accessing NPM content through a CDN, such
-as <a target="_blank" href="https://unpkg.com/">UNPKG</a> and <a target="_blank" href="https://www.jsdelivr.com/">jsDelivr</a>. Here is an example of loading the 0.2.* version of `va-report-components` from UNPKG
-using an HTML `script` tag.
+as <a target="_blank" href="https://unpkg.com/">UNPKG</a> and <a target="_blank" href="https://www.jsdelivr.com/">jsDelivr</a>. Here is an example of loading the 0.3.* version of `va-report-components` from UNPKG
+using an HTML `script` tag. When used in production, the version should be pinned to the full `major.minor.patch` semantic version.
 
 ```html
-<script async src="https://unpkg.com/@sassoftware/va-report-components@0.2/dist/umd/va-report-components.js"></script>
+<script async src="https://unpkg.com/@sassoftware/va-report-components@0.3/dist/umd/va-report-components.js"></script>
 ```
 
 ## Getting Started

--- a/examples/SASReportElement.html
+++ b/examples/SASReportElement.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.2/dist/umd/va-report-components.js"></script>
+    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.3/dist/umd/va-report-components.js"></script>
     <style>
       html {
         background-color: #f0f0f0;

--- a/examples/SASReportElementJS.html
+++ b/examples/SASReportElementJS.html
@@ -5,7 +5,7 @@
         background-color: #f0f0f0;
       }
     </style>
-    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.2/dist/umd/va-report-components.js"></script>
+    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.3/dist/umd/va-report-components.js"></script>
   </head>
   <body></body>
   <script> 

--- a/examples/SASReportObjectElement.html
+++ b/examples/SASReportObjectElement.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.2/dist/umd/va-report-components.js"></script>
+    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.3/dist/umd/va-report-components.js"></script>
     <style>
       html {
         background-color: #f0f0f0;

--- a/examples/connectToServer.html
+++ b/examples/connectToServer.html
@@ -5,7 +5,7 @@
         background-color: #f0f0f0;
       }
     </style>
-    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.2/dist/umd/va-report-components.js"></script>
+    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.3/dist/umd/va-report-components.js"></script>
   </head>
   <body></body>
   <script>

--- a/examples/registerDataDrivenContent.html
+++ b/examples/registerDataDrivenContent.html
@@ -4,7 +4,7 @@
     <title>SAS Visual Analytics Custom Data Table</title>
     <script
       async
-      src="https://unpkg.com/@sassoftware/va-report-components@0.2/dist/umd/va-report-components.js"
+      src="https://unpkg.com/@sassoftware/va-report-components@0.3/dist/umd/va-report-components.js"
     ></script>
     <style>
       body {


### PR DESCRIPTION
Update to use new version in code samples on readme and examples.  Also, add changelog entry for v0.3.0