### PR TITLE
0.5.0 doc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,10 @@
 
 - Add ReportHandle API with support for report parameters
 - Bug fixes
+
+## 0.5.0 (May 27, 2020)
+
+- Add support for custom report themes
+- Add support for SAS Graphics Accelerator
+- Keyboard and focus accessibility fixes
+- Bug fixes

--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ Access to a deployment of SAS Visual Analytics 8.4 (or later) is necessary in or
 
 ### NPM
 
-The <a target="_blank" href="https://www.npmjs.com/package/@sassoftware/va-report-components">`@sassoftware/va-report-components`</a> library is published to NPM and can be installed by running the following command. `va-report-components` does not support ES6 imports, therefore the contents of the va-report-components `dist/umd` folder must be deployed with your page and loaded using a script tag.
+The <a target="_blank" href="https://www.npmjs.com/package/@sassoftware/va-report-components">`@sassoftware/va-report-components`</a> library is published to NPM and can be installed by running the `npm install` command as shown below. `va-report-components` does not support ES6 imports. Therefore, the contents of the `va-report-components/dist` folder must be deployed with your page, and then loaded using a `script` tag.
 
 ```bash
 # From the root directory of your project
 npm install @sassoftware/va-report-components
 
 # Copy the contents of the package to an asset folder for deployment
-cp -r ./node_modules/@sassoftware/va-report-components/dist/umd ./sdk-assets
+cp -r ./node_modules/@sassoftware/va-report-components/dist ./sdk-assets
 ```
 
 The library can then be loaded out of the deployed assets folder using a `script` tag.
 
 ```html
-<script async src="./sdk-assets/va-report-components.js"></script>
+<script async src="./sdk-assets/dist/umd/va-report-components.js"></script>
 ```
 
 ### CDN (Content Delivery Network)

--- a/README.md
+++ b/README.md
@@ -15,22 +15,31 @@ Access to a deployment of SAS Visual Analytics 8.4 (or later) is necessary in or
 
 ### NPM
 
-The <a target="_blank" href="https://www.npmjs.com/package/@sassoftware/va-report-components">`@sassoftware/va-report-components`</a> library is published to NPM and can be installed by running the following command.
+The <a target="_blank" href="https://www.npmjs.com/package/@sassoftware/va-report-components">`@sassoftware/va-report-components`</a> library is published to NPM and can be installed by running the following command. `va-report-components` does not support ES6 imports, therefore the contents of the va-report-components `dist/umd` folder must be deployed with your page and loaded using a script tag.
 
 ```bash
 # From the root directory of your project
 npm install @sassoftware/va-report-components
+
+# Copy the contents of the package to an asset folder for deployment
+cp -r ./node_modules/@sassoftware/va-report-components/dist/umd ./sdk-assets
+```
+
+The library can then be loaded out of the deployed assets folder using a `script` tag.
+
+```html
+<script async src="./sdk-assets/va-report-components.js"></script>
 ```
 
 ### CDN (Content Delivery Network)
 
 Accessing the `va-report-components` library from a CDN is easy. It does not require installation or
 hosting of the library code and assets. There are several public options for accessing NPM content through a CDN, such
-as <a target="_blank" href="https://unpkg.com/">UNPKG</a> and <a target="_blank" href="https://www.jsdelivr.com/">jsDelivr</a>. Here is an example of loading the 0.4.* version of `va-report-components` from UNPKG
+as <a target="_blank" href="https://unpkg.com/">UNPKG</a> and <a target="_blank" href="https://www.jsdelivr.com/">jsDelivr</a>. Here is an example of loading the 0.5.* version of `va-report-components` from UNPKG
 using an HTML `script` tag. When used in production, the version should be pinned to the full `major.minor.patch` semantic version.
 
 ```html
-<script async src="https://unpkg.com/@sassoftware/va-report-components@0.4/dist/umd/va-report-components.js"></script>
+<script async src="https://unpkg.com/@sassoftware/va-report-components@0.5/dist/umd/va-report-components.js"></script>
 ```
 
 ## Getting Started

--- a/documentation/docs/api-reference.md
+++ b/documentation/docs/api-reference.md
@@ -21,27 +21,11 @@ When you load the library with a script element, the `vaReportComponents` global
 assets are loaded. The `vaReportComponents.loaded` event is dispatched once it is ready.
 
 ```html
-<script async src="https://unpkg.com/@sassoftware/va-report-components@0.4/dist/umd/va-report-components.js"></script>
+<script async src="https://unpkg.com/@sassoftware/va-report-components@0.5/dist/umd/va-report-components.js"></script>
 <script>
   window.addEventListener('vaReportComponents.loaded', function() {
     // The SAS Visual Analytics SDK is loaded and ready
     const connectToServer = vaReportComponents.connectToServer;
   });
 </script>
-```
-
-## Importing
-
-All top-level exports can be imported like this:
-
-### ES5 (UMD)
-
-```javascript
-const connectToServer = vaReportComponents.connectToServer;
-```
-
-### ES6
-
-```javascript
-import { connectToServer } from '@sassoftware/va-report-components';
 ```

--- a/documentation/docs/faq.md
+++ b/documentation/docs/faq.md
@@ -72,7 +72,3 @@ This message means that you have multiple uses of the same report object - eithe
 ## Why does nothing happen when I click a report link?
 
 Report linking is not currently supported in the SAS Visual Analytics SDK.  All other action types are supported.
-
-## Where is my custom report theme?
-
-Custom report themes are not currently supported in the SAS Visual Analytics SDK.

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -11,20 +11,20 @@ You can embed entire reports with the `<sas-report>` custom HTML element, embed 
 
 ### NPM
 
-The <a target="_blank" href="https://www.npmjs.com/package/@sassoftware/va-report-components">`@sassoftware/va-report-components`</a> library is published to NPM and can be installed by running the following command. `va-report-components` does not support ES6 imports, therefore the contents of the va-report-components `dist/umd` folder must be deployed with your page and loaded using a script tag.
+The <a target="_blank" href="https://www.npmjs.com/package/@sassoftware/va-report-components">`@sassoftware/va-report-components`</a> library is published to NPM and can be installed by running the `npm install` command as shown below. `va-report-components` does not support ES6 imports. Therefore, the contents of the `va-report-components/dist` folder must be deployed with your page, and then loaded using a `script` tag.
 
 ```bash
 # From the root directory of your project
 npm install @sassoftware/va-report-components
 
 # Copy the contents of the package to an asset folder for deployment
-cp -r ./node_modules/@sassoftware/va-report-components/dist/umd ./sdk-assets
+cp -r ./node_modules/@sassoftware/va-report-components/dist ./sdk-assets
 ```
 
 The library can then be loaded out of the deployed assets folder using a `script` tag.
 
 ```html
-<script async src="./sdk-assets/va-report-components.js"></script>
+<script async src="./sdk-assets/dist/umd/va-report-components.js"></script>
 ```
 
 ### CDN (Content Delivery Network)

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -11,22 +11,31 @@ You can embed entire reports with the `<sas-report>` custom HTML element, embed 
 
 ### NPM
 
-The <a target="_blank" href="https://www.npmjs.com/package/@sassoftware/va-report-components">`@sassoftware/va-report-components`</a> library is published to NPM and can be installed by running the following command.
+The <a target="_blank" href="https://www.npmjs.com/package/@sassoftware/va-report-components">`@sassoftware/va-report-components`</a> library is published to NPM and can be installed by running the following command. `va-report-components` does not support ES6 imports, therefore the contents of the va-report-components `dist/umd` folder must be deployed with your page and loaded using a script tag.
 
 ```bash
 # From the root directory of your project
 npm install @sassoftware/va-report-components
+
+# Copy the contents of the package to an asset folder for deployment
+cp -r ./node_modules/@sassoftware/va-report-components/dist/umd ./sdk-assets
+```
+
+The library can then be loaded out of the deployed assets folder using a `script` tag.
+
+```html
+<script async src="./sdk-assets/va-report-components.js"></script>
 ```
 
 ### CDN (Content Delivery Network)
 
 Accessing the `va-report-components` library from a CDN is easy. It does not require installation or
 hosting of the library code and assets. There are several public options for accessing NPM content through a CDN, such
-as <a target="_blank" href="https://unpkg.com/">UNPKG</a> and <a target="_blank" href="https://www.jsdelivr.com/">jsDelivr</a>. Here is an example of loading the 0.4.* version of `va-report-components` from UNPKG
+as <a target="_blank" href="https://unpkg.com/">UNPKG</a> and <a target="_blank" href="https://www.jsdelivr.com/">jsDelivr</a>. Here is an example of loading the 0.5.* version of `va-report-components` from UNPKG
 using an HTML `script` tag. When used in production, the version should be pinned to the full `major.minor.patch` semantic version.
 
 ```html
-<script async src="https://unpkg.com/@sassoftware/va-report-components@0.4/dist/umd/va-report-components.js"></script>
+<script async src="https://unpkg.com/@sassoftware/va-report-components@0.5/dist/umd/va-report-components.js"></script>
 ```
 
 ## SAS Viya setup

--- a/examples/SASReportElement.html
+++ b/examples/SASReportElement.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.4/dist/umd/va-report-components.js"></script>
+    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.5/dist/umd/va-report-components.js"></script>
     <style>
       html {
         background-color: #f0f0f0;

--- a/examples/SASReportElementJS.html
+++ b/examples/SASReportElementJS.html
@@ -5,7 +5,7 @@
         background-color: #f0f0f0;
       }
     </style>
-    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.4/dist/umd/va-report-components.js"></script>
+    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.5/dist/umd/va-report-components.js"></script>
   </head>
   <body></body>
   <script> 

--- a/examples/SASReportObjectElement.html
+++ b/examples/SASReportObjectElement.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.4/dist/umd/va-report-components.js"></script>
+    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.5/dist/umd/va-report-components.js"></script>
     <style>
       html {
         background-color: #f0f0f0;

--- a/examples/connectToServer.html
+++ b/examples/connectToServer.html
@@ -5,7 +5,7 @@
         background-color: #f0f0f0;
       }
     </style>
-    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.4/dist/umd/va-report-components.js"></script>
+    <script async src="https://unpkg.com/@sassoftware/va-report-components@0.5/dist/umd/va-report-components.js"></script>
   </head>
   <body></body>
   <script>

--- a/examples/registerDataDrivenContent.html
+++ b/examples/registerDataDrivenContent.html
@@ -4,7 +4,7 @@
     <title>SAS Visual Analytics Custom Data Table</title>
     <script
       async
-      src="https://unpkg.com/@sassoftware/va-report-components@0.4/dist/umd/va-report-components.js"
+      src="https://unpkg.com/@sassoftware/va-report-components@0.5/dist/umd/va-report-components.js"
     ></script>
     <style>
       body {


### PR DESCRIPTION
These are the doc updates for v0.5.0.

* Update all 0.4 references to 0.5
* Update changelog
* Remove FAQ entry for unsupported custom report themes (now supported)
* Remove documentation for using ES5 and ES6 imports
* Update installation doc (readme and gettingStarted) to show copying npm package to deployment location and referencing with script tag