### PR TITLE
Add doc for menuItemProvider

### DIFF
--- a/documentation/docs/api/MenuItemProvider.md
+++ b/documentation/docs/api/MenuItemProvider.md
@@ -1,0 +1,63 @@
+---
+id: MenuItemProvider
+title: MenuItemProvider
+---
+
+## MenuItemProvider: `(target: Object) => Object[]`
+A MenuItemProvider is a callback function, provided to an SDK report element, that is used to generate custom menu items.  The menu items are shown along with other built-in context menu items and object toolbar menu items.
+
+
+## Arguments
+
+### `target: {type: 'report'} | {type: 'object', name: string}`
+
+An object describing the menu target.  The MenuItemProvider is used to generate menu items for the report and for individual objects in a report.  `target` gives context for which menu items should be generated. The MenuItemProvider callback should check the target information and return the desired custom menu items appropriately.  When type is `report` the returned menu items are shown in the context menu regardless of where in a report the user right-clicks.  When type is `object` the returned menu items are shown in both the context menu and object toolbar menu of the object with name matching the `name` property of `target`.
+
+## Return value
+
+A MenuItemProvider callback should return an array of menu item objects.  Each menu item has the following form:
+
+- `text: string`: The text label that is shown in the menu
+- `callback: () => void`: The callback function to call when the menu item is clicked
+
+The content of the returned menu items should be be provided conditionally, based on the `target` parameter.  If no menu items are desired for a given `target`, an empty `Array` should be returned.
+
+## Example
+
+In this example, a custom menu is provided such that the report menu has two custom menu items, and each object has two custom menu items.
+The object menu items use the `target.name` to customize the text shown in the menu.
+
+```javascript
+const sasReport = getElementById("my-report");
+// Set the custom provider function to the menuItemProvider property
+sasReport.menuItemProvider = (target) => {
+  if (target.type === "report") {
+    // Return the menu items that relate to the entire report
+    return [
+      {
+        // The string that will be shown in the menu UI
+        text: "Report Action 1",
+        // The function that will be called when the user clicks this menu item
+        callback: () => console.log("Doing report action 1"),
+      },
+      {
+        text: "Report Action 2",
+        callback: () => console.log("Doing report action 2"),
+      },
+    ];
+  } else if (target.type === "object") {
+    // Return the menu items that relate to the object with name target.name
+    return [
+      {
+        text: `Object ${target.name} Action 1`,
+        callback: () => console.log(`Doing object ${target.name} action 1`),
+      },
+      {
+        text: `Object ${target.name} Action 2`,
+        callback: () => console.log(`Doing object ${target.name} action 2`),
+      },
+    ];
+  }
+  return [];
+};
+```

--- a/documentation/docs/api/SASReportElement.md
+++ b/documentation/docs/api/SASReportElement.md
@@ -46,6 +46,12 @@ than one section.
 
 default value: `'auto'`
 
+## Properties
+
+### `menuItemProvider: MenuItemProvider`
+
+A [`MenuItemProvider`](MenuItemProvider.md) function that generates custom menu content for this element.
+
 ## Methods
 
 ### `getReportHandle(): Promise<ReportHandle>`

--- a/documentation/docs/api/SASReportObjectElement.md
+++ b/documentation/docs/api/SASReportObjectElement.md
@@ -43,6 +43,12 @@ Specify the report URI.
 
 Specify the name of the object from the report to display.
 
+## Properties
+
+### `menuItemProvider: MenuItemProvider`
+
+A [`MenuItemProvider`](MenuItemProvider.md) function that generates custom menu content for this element.
+
 ## Methods
 
 ### `getReportHandle(): Promise<ReportHandle>`

--- a/documentation/docs/api/SASReportPageElement.md
+++ b/documentation/docs/api/SASReportPageElement.md
@@ -46,6 +46,12 @@ Specify the name of the report page that you want to display. Either `pageName` 
 
 Specify the index of the report page that you want to display. `0` is the first page. Either `pageName` or `pageIndex` can be used, but not both.
 
+## Properties
+
+### `menuItemProvider: MenuItemProvider`
+
+A [`MenuItemProvider`](MenuItemProvider.md) function that generates custom menu content for this element.
+
 ## Methods
 
 ### `getReportHandle(): Promise<ReportHandle>`

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -102,4 +102,4 @@ For a complete list of options, see the documentation for [`SASReportElement`](a
 ## See our examples
 
 <a target="_blank" href="https://github.com/sassoftware/visual-analytics-sdk/tree/master/examples">Our examples</a> demonstrate a few different
-ways to start using the Visual Analytics SDK in your HTML application.
+ways to start using the SAS Visual Analytics SDK in your HTML application.

--- a/documentation/website/sidebars.json
+++ b/documentation/website/sidebars.json
@@ -8,6 +8,7 @@
       "api/SASReportPageElement",
       "api/SASReportObjectElement",
       "api/ReportHandle",
+      "api/MenuItemProvider",
       "api/connectToServer",
       "api/registerDataDrivenContent",
       "api/DataDrivenContentHandle"


### PR DESCRIPTION
I have deployed this doc change to http://dvr.na.sas.com/sdk/va/docs/next/getting-started/ which may be easier to review in context.

@joylashley, let me know if you need more context about the actual feature.  Hopefully the new doc is self explanatory.