### PR TITLE
add Viya setup guide

### DIFF
--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -40,32 +40,7 @@ using an HTML `script` tag. When used in production, the version should be pinne
 
 ## SAS Viya setup
 
-### Enable Cross-Origin Resource Sharing
-
-By default, your SAS Viya deployment is not set up to allow access to REST API endpoints from different domains. This is
-needed in order to connect to SAS Viya from the domain that is hosting your HTML page. This domain needs to be added to the
-`allowOrigins` property in SAS Viya deployment's CORS configuration. See
-<a target="_blank" href="https://developer.sas.com/reference/cors/">developer.sas.com</a> and
-<a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=p1gq6q7zzt52win1jwhc2b5kuc1z.htm&locale=en#p04ifnaixhf85in1xo7zrr2fgimf">SAS Help Center</a> for more information.
-
-### Cross-Site Request Forgery
-
-SAS Viya servers protect against Cross-Site Request Forgery (CSRF) by blocking requests where the HTTP Referer Header does not match the URI of the requested resource or a URI whitelist. The domain of the site using the SAS Visual Analytics SDK must be whitelisted in the CSRF configuration.  See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calconfigref&docsetTarget=p1fejrlg8b007jn1krvvwzy5q7tn.htm#n0nf0wwa3p7mjhn11926x4k9gl72">SAS Help Center</a> for more information.
-
-### Cross-Site Cookies
-
-The SAS Visual Analytics SDK requires the use of cookies to handle authentication with the SAS Viya Logon service. Browsers require that the response setting the cookie explicitly enable cross-site cookies by setting `samesite=none` on the response header. This is not the default for SAS Viya and must be configured in order to support the SDK. The `sameSite` configuration option in the `sas.commons.web.security.cookies` definition should be set to `None`, and should be applied globally to all services. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calconfigref&docsetTarget=p1fejrlg8b007jn1krvvwzy5q7tn.htm#p0xav129qcxrytn14y2d8rnhdrlm">SAS Help Center</a> for more information.
-
-Note: If you have enabled settings that block cookies in your web browser, then the VA SDK cannot authenticate with SAS Viya. Check your settings to make sure your web browser allows third-party cookies.
-
-#### HTTPS
-It is also a requirement that SAS Viya be accessed using the HTTPS protocol in order for web browsers to allow cross-site cookies to be set by SAS Viya.  This requires that TLS (Transport Layer Security) be enabled on your SAS Viya deployment. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calencryptmotion&docsetTarget=n1bktkey9qb5z0n14fji0ss0b453.htm#p11136ylabo3k1n1rwctv2xrn8js">SAS Help Center</a> for more information.
-
-### Allow guest access
-
-The SAS Visual Analytics SDK has the option to connect to the SAS Viya server using guest authentication. This requires that the SAS Viya system be
-set up to enable guest access, and that the guest user has access to the appropriate report content and data. For more information, see 
-<a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=n067qoyrgu1yohn19nq4ehy8o0b3.htm">SAS Help Center</a>.
+The SAS Visual Analytics SDK requires connecting to SAS Viya server.  Server setup requirements are covered in the [SAS Viya Setup Guide](guides/viya-setup.md).
 
 ## Include a custom elements polyfill
 

--- a/documentation/docs/guides/viya-setup.md
+++ b/documentation/docs/guides/viya-setup.md
@@ -3,15 +3,15 @@ id: viya-setup
 title: SAS Viya Setup
 ---
 
-This guide will walk you through modifying the SAS Viya security settings necessary to connect to it using the SAS Visual Analytics SDK. The changes are made by accessing SAS Environment Manager with administrator credentials.
+This guide explains how to modify the SAS Viya security settings to connect to the SAS Visual Analytics SDK. You need administrator credentials to make these changes using SAS Environment Manager.
 
-Note: The configuration changes listed below should all be made to the global context, applying to all services. All services should be restarted after making the changes.
+Note: The configuration changes listed below should all be made to the global context, applying to all services. Restart all services after making the changes.
 
 ## Enable Cross-Origin Resource Sharing
 
 By default, your SAS Viya deployment is not set up to allow access to REST API endpoints from different domains. This is
 needed in order to connect to SAS Viya from the domain that is hosting your HTML page. This domain needs to be added to the
-`allowOrigins` property in SAS Viya deployment's CORS configuration. This can be done by following the <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=p1gq6q7zzt52win1jwhc2b5kuc1z.htm&locale=en#p04ifnaixhf85in1xo7zrr2fgimf">Configure Cross-Origin Resource Sharing</a> documentation. Note that the `allowedOrigins` property does not support using the value `*` to support all origins. You must explicitly add you domain, or a list of domains.
+`allowOrigins` property in SAS Viya deployment's CORS configuration. This can be done by following the <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=p1gq6q7zzt52win1jwhc2b5kuc1z.htm&locale=en#p04ifnaixhf85in1xo7zrr2fgimf">Configure Cross-Origin Resource Sharing</a> documentation. Note that the `allowedOrigins` property does not support using the value `*` to support all origins. You must explicitly add you domain or a list of domains.
 
 ## Cross-Site Request Forgery
 
@@ -19,15 +19,14 @@ SAS Viya servers protect against Cross-Site Request Forgery (CSRF) by blocking r
 
 ## Cross-Site Cookies
 
-The SAS Visual Analytics SDK requires the use of cookies to handle authentication with the SAS Viya Logon service. Browsers require that the response setting the cookie explicitly enable cross-site cookies by setting `samesite=none` on the response header. This is not the default for SAS Viya and must be configured in order to support the SDK. The `sameSite` configuration option in the `sas.commons.web.security.cookies` definition should be set to `None`, and should be applied globally to all services. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calconfigref&docsetTarget=p1fejrlg8b007jn1krvvwzy5q7tn.htm#p0xav129qcxrytn14y2d8rnhdrlm">SAS Help Center</a> for more information.
+The SAS Visual Analytics SDK requires the use of cookies to handle authentication with the SAS Viya Logon service. Browsers require that the response setting the cookie explicitly enable cross-site cookies by setting `samesite=none` on the response header. This is not the default for SAS Viya, so you must configure it to support the SAS Visual Analytics SDK. The `sameSite` configuration option in the `sas.commons.web.security.cookies` definition should be set to `None`, and should be applied globally to all services. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calconfigref&docsetTarget=p1fejrlg8b007jn1krvvwzy5q7tn.htm#p0xav129qcxrytn14y2d8rnhdrlm">SAS Help Center</a> for more information.
 
-Note: If you have enabled settings that block cookies in your web browser, then the VA SDK cannot authenticate with SAS Viya. Check your settings to make sure your web browser allows third-party cookies.
+Note: If you have enabled settings that block cookies in your web browser, then the SAS Visual Analytics SDK cannot authenticate with SAS Viya. Check your settings to make sure your web browser allows third-party cookies.
 
 ### HTTPS
-It is also a requirement that SAS Viya be accessed using the HTTPS protocol in order for web browsers to allow cross-site cookies to be set by SAS Viya.  This requires that TLS (Transport Layer Security) be enabled on your SAS Viya deployment. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calencryptmotion&docsetTarget=n1bktkey9qb5z0n14fji0ss0b453.htm#p11136ylabo3k1n1rwctv2xrn8js">SAS Help Center</a> for more information.
+It is also a requirement that SAS Viya be accessed using the HTTPS protocol in order for web browsers to allow cross-site cookies to be set by SAS Viya. This requires that TLS (Transport Layer Security) be enabled on your SAS Viya deployment. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calencryptmotion&docsetTarget=n1bktkey9qb5z0n14fji0ss0b453.htm#p11136ylabo3k1n1rwctv2xrn8js">SAS Help Center</a> for more information.
 
 ## Allow guest access
 
-The SAS Visual Analytics SDK has the option to connect to the SAS Viya server using guest authentication. This requires that the SAS Viya system be
-set up to enable guest access, and that the guest user has access to the appropriate report content and data. For more information, see 
+The SAS Visual Analytics SDK has the option to connect to the SAS Viya server using guest authentication. This requires that SAS Viya be set up to enable guest access, and that the guest user has access to the appropriate report content and data. For more information, see 
 <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=n067qoyrgu1yohn19nq4ehy8o0b3.htm">SAS Help Center</a>.

--- a/documentation/docs/guides/viya-setup.md
+++ b/documentation/docs/guides/viya-setup.md
@@ -15,7 +15,7 @@ needed in order to connect to SAS Viya from the domain that is hosting your HTML
 
 ## Cross-Site Request Forgery
 
-SAS Viya servers protect against Cross-Site Request Forgery (CSRF) by blocking requests where the HTTP Referer Header does not match the URI of the requested resource or the `allowedUris` CSRF configuration property. The domain of the site using the SAS Visual Analytics SDK must be allowed in the CSRF configuration by setting `allowedUris` to a regular expression that matches the domain. For example, the regular expression `.*` will match all domains.  See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calconfigref&docsetTarget=p1fejrlg8b007jn1krvvwzy5q7tn.htm#n0nf0wwa3p7mjhn11926x4k9gl72">SAS Help Center</a> for more information.
+SAS Viya protects against Cross-Site Request Forgery (CSRF) by blocking requests where the HTTP Referer Header does not match the URI of the requested resource or the `allowedUris` CSRF configuration property. The domain of the site using the SAS Visual Analytics SDK must be allowed in the CSRF configuration by setting `allowedUris` to a regular expression that matches the domain. For example, the regular expression `.*` will match all domains.  See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calconfigref&docsetTarget=p1fejrlg8b007jn1krvvwzy5q7tn.htm#n0nf0wwa3p7mjhn11926x4k9gl72">SAS Help Center</a> for more information.
 
 ## Cross-Site Cookies
 
@@ -28,5 +28,5 @@ It is also a requirement that SAS Viya be accessed using the HTTPS protocol in o
 
 ## Allow guest access
 
-The SAS Visual Analytics SDK has the option to connect to the SAS Viya server using guest authentication. This requires that SAS Viya be set up to enable guest access, and that the guest user has access to the appropriate report content and data. For more information, see 
+The SAS Visual Analytics SDK has the option to connect to SAS Viya using guest authentication. This requires that SAS Viya be set up to enable guest access, and that the guest user has access to the appropriate report content and data. For more information, see 
 <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=n067qoyrgu1yohn19nq4ehy8o0b3.htm">SAS Help Center</a>.

--- a/documentation/docs/guides/viya-setup.md
+++ b/documentation/docs/guides/viya-setup.md
@@ -1,0 +1,33 @@
+---
+id: viya-setup
+title: SAS Viya Setup
+---
+
+This guide will walk you through modifying the SAS Viya security settings necessary to connect to it using the SAS Visual Analytics SDK. The changes are made by accessing SAS Environment Manager with administrator credentials.
+
+Note: The configuration changes listed below should all be made to the global context, applying to all services. All services should be restarted after making the changes.
+
+## Enable Cross-Origin Resource Sharing
+
+By default, your SAS Viya deployment is not set up to allow access to REST API endpoints from different domains. This is
+needed in order to connect to SAS Viya from the domain that is hosting your HTML page. This domain needs to be added to the
+`allowOrigins` property in SAS Viya deployment's CORS configuration. This can be done by following the <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=p1gq6q7zzt52win1jwhc2b5kuc1z.htm&locale=en#p04ifnaixhf85in1xo7zrr2fgimf">Configure Cross-Origin Resource Sharing</a> documentation. Note that the `allowedOrigins` property does not support using the value `*` to support all origins. You must explicitly add you domain, or a list of domains.
+
+## Cross-Site Request Forgery
+
+SAS Viya servers protect against Cross-Site Request Forgery (CSRF) by blocking requests where the HTTP Referer Header does not match the URI of the requested resource or the `allowedUris` CSRF configuration property. The domain of the site using the SAS Visual Analytics SDK must be allowed in the CSRF configuration by setting `allowedUris` to a regular expression that matches the domain. For example, the regular expression `.*` will match all domains.  See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calconfigref&docsetTarget=p1fejrlg8b007jn1krvvwzy5q7tn.htm#n0nf0wwa3p7mjhn11926x4k9gl72">SAS Help Center</a> for more information.
+
+## Cross-Site Cookies
+
+The SAS Visual Analytics SDK requires the use of cookies to handle authentication with the SAS Viya Logon service. Browsers require that the response setting the cookie explicitly enable cross-site cookies by setting `samesite=none` on the response header. This is not the default for SAS Viya and must be configured in order to support the SDK. The `sameSite` configuration option in the `sas.commons.web.security.cookies` definition should be set to `None`, and should be applied globally to all services. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calconfigref&docsetTarget=p1fejrlg8b007jn1krvvwzy5q7tn.htm#p0xav129qcxrytn14y2d8rnhdrlm">SAS Help Center</a> for more information.
+
+Note: If you have enabled settings that block cookies in your web browser, then the VA SDK cannot authenticate with SAS Viya. Check your settings to make sure your web browser allows third-party cookies.
+
+### HTTPS
+It is also a requirement that SAS Viya be accessed using the HTTPS protocol in order for web browsers to allow cross-site cookies to be set by SAS Viya.  This requires that TLS (Transport Layer Security) be enabled on your SAS Viya deployment. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calencryptmotion&docsetTarget=n1bktkey9qb5z0n14fji0ss0b453.htm#p11136ylabo3k1n1rwctv2xrn8js">SAS Help Center</a> for more information.
+
+## Allow guest access
+
+The SAS Visual Analytics SDK has the option to connect to the SAS Viya server using guest authentication. This requires that the SAS Viya system be
+set up to enable guest access, and that the guest user has access to the appropriate report content and data. For more information, see 
+<a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=n067qoyrgu1yohn19nq4ehy8o0b3.htm">SAS Help Center</a>.

--- a/documentation/website/sidebars.json
+++ b/documentation/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Introduction": ["getting-started"],
-    "Guides": ["guides/data-driven-content"],
+    "Guides": ["guides/viya-setup", "guides/data-driven-content"],
     "API Reference": [
       "api-reference",
       "api/SASReportElement",


### PR DESCRIPTION
Restructuring to move all viya setup information out of the 'Getting Started' page and into its own guide page.