### PR TITLE
add doc for setLoadingTheme

### DIFF
--- a/documentation/docs/api-reference.md
+++ b/documentation/docs/api-reference.md
@@ -15,6 +15,7 @@ to use SAS data to drive your own components or visualizations.
 - [`registerDataDrivenContent`](api/registerDataDrivenContent.md)
 - [`DataDrivenContentHandle`](api/DataDrivenContentHandle.md)
 - [`setUseHighContrastReportTheme`](api/setUseHighContrastReportTheme.md)
+- [`setLoadingTheme`](api/setLoadingTheme.md)
 
 ## Loading with \<script\>
 

--- a/documentation/docs/api/setLoadingTheme.md
+++ b/documentation/docs/api/setLoadingTheme.md
@@ -1,0 +1,50 @@
+---
+id: setLoadingTheme
+title: setLoadingTheme
+---
+
+```
+setLoadingTheme(options): void
+```
+
+`setLoadingTheme` allows the user to set the theme of the sdk before a report loads. You might want to set the theme for the initial loading state to match the website that the SAS Visual Analytic SDK is embedded in. You also might want to set the loading theme to be consistent with the report that will be loaded.
+
+
+`setLoadingTheme` only affects the initial loading and logon states. It does not affect the report theme once a report has been loaded.
+
+## Arguments
+
+### `options: Object | 'light' | 'dark' | 'high-contrast'`
+
+When you select `'light'`, `'dark'`, or `'high-contrast'`, then the loading theme is based on one of the built-in themes.
+
+
+Alternatively, you can specify theme values. The following optional properties are supported:
+
+- `baseTheme: 'light' | 'dark'`: The base theme that is used for loading the theme values. The theme values are used when no defaults are provided. For example, if backgroundColor is not specified and the baseTheme is light, then the backgoundColor will be white since that is the theme's background color. **default**:`light`
+
+You can further customize the loading style with additional style properties. Some examples are provided below to show you how certain options affect the theme. The following style overrides are available:
+- `primary: string`: The logon button background and loading indicator.
+- `backgroundColor: string`
+- `textColor: string`
+- `textColorInverse: string` The button text color for the logon state.
+- `fontFamily: string`
+
+
+### Examples
+
+```javascript
+  window.addEventListener('vaReportComponents.loaded', function() {
+    vaReportComponents.setLoadingTheme('dark');
+  });
+```
+
+```javascript
+  window.addEventListener('vaReportComponents.loaded', function() {
+    vaReportComponents.setLoadingTheme({
+      baseTheme: 'dark',
+      primary: '#FFA500',
+      fontFamily: 'Gothic',
+    });
+  });
+```

--- a/documentation/website/sidebars.json
+++ b/documentation/website/sidebars.json
@@ -14,7 +14,8 @@
       "api/connectToServer",
       "api/registerDataDrivenContent",
       "api/DataDrivenContentHandle",
-      "api/setUseHighContrastReportTheme"
+      "api/setUseHighContrastReportTheme",
+      "api/setLoadingTheme"
     ],
     "Resources": ["faq"]
   }


### PR DESCRIPTION
Add doc for a new api that enables the sdk to set the theme for the loading theme. This is needed since this is before the report is loaded and the consumer may want to customize this theme to match the report that will be loaded or the webite that is using the sdk.