### PR TITLE
add export option for enablePdfAccessibleTags

### DIFF
--- a/documentation/docs/api/ExportPDFOptions.md
+++ b/documentation/docs/api/ExportPDFOptions.md
@@ -76,3 +76,6 @@ default value: `''`
 A list of report object names for the objects to include in the exported PDF. If empty, the entire report will be exported.
 
 default value: `[]`
+
+### `enablePdfAccessibleTags: boolean`
+Enables you to create a tagged PDF, which contains accessibility markup that optimizes the reading experience for users who use screen readers or other assistive technology.


### PR DESCRIPTION
Adds the export option enablePdfAccessibleTags to the list of export options. 

I pulled the wording for the description of enablePdfAccessibleTags from [VA's printing documentation](https://go.documentation.sas.com/doc/en/vacdc/8.5/vavwr/n15v2qs7o9lfdin1diztpvux34ch.htm). 