### PR TITLE
add doc for exportPDF for objects

### DIFF
--- a/documentation/docs/api/ObjectHandle.md
+++ b/documentation/docs/api/ObjectHandle.md
@@ -26,6 +26,14 @@ Supported formats:
 
 If no `options` parameter is supplied, the data will be exported using the default option values. 
 
+### exportPDF(options?: ExportPDFOptions): Promise\<string>
+
+Exports a PDF of the report object and returns a URL to the PDF document. 
+
+`options` is an [`ExportPDFOptions`](ExportPDFOptions.md) that controls the format of the exported PDF document. The option `includedReportObjects` does not apply when exporting a report object.
+
+If no `options` parameter is supplied, the report will be exported using the default options values.
+
 ### refreshData(): void
 
 Refreshes the data for the report object that is controlled by the

--- a/documentation/docs/api/ObjectHandle.md
+++ b/documentation/docs/api/ObjectHandle.md
@@ -32,7 +32,7 @@ Exports a PDF of the report object and returns a URL to the PDF document.
 
 `options` is an [`ExportPDFOptions`](ExportPDFOptions.md) that controls the format of the exported PDF document. The option `includedReportObjects` does not apply when exporting a report object.
 
-If no `options` parameter is supplied, the report will be exported using the default options values.
+If no `options` parameter is supplied, the report is exported using the default options values.
 
 ### refreshData(): void
 

--- a/documentation/docs/api/ReportHandle.md
+++ b/documentation/docs/api/ReportHandle.md
@@ -116,7 +116,7 @@ sasReport.getReportHandle().then((reportHandle) => {
 Exports a PDF of the report and returns a URL to the PDF document.
 
 `options` is an [`ExportPDFOptions`](ExportPDFOptions.md) that controls the format of the exported PDF document.
-If no `options` parameter is supplied, the report will be exported using the default options values.
+If no `options` parameter is supplied, the report is exported using the default options values.
 
 #### Example
 


### PR DESCRIPTION
Added exportPDF to ObjectHandle. I pulled most of the wording from exportPDF in ReportHandle for consistency. 