### PR TITLE
Change doc reference to SAS Developer CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The library can then be loaded out of the deployed assets folder using a `script
 
 ### CDN (Content Delivery Network)
 
-Accessing the `va-report-components` library from the SAS CDN is easy. It does not require installation or
+Accessing the `va-report-components` library from the SAS Developer CDN is easy. It does not require installation or
 hosting of the library code and assets. Here is an example of loading the latest version of `va-report-components` from the CDN using an HTML `script` tag.
 
 ```html

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -29,7 +29,7 @@ The library can then be loaded out of the deployed assets folder using a `script
 
 ### CDN (Content Delivery Network)
 
-Accessing the `va-report-components` library from the SAS CDN is easy. It does not require installation or
+Accessing the `va-report-components` library from the SAS Developer CDN is easy. It does not require installation or
 hosting of the library code and assets. Here is an example of loading the latest version of `va-report-components` from the CDN using an HTML `script` tag.
 
 ```html

--- a/documentation/website/versioned_docs/version-1.8.0/getting-started.md
+++ b/documentation/website/versioned_docs/version-1.8.0/getting-started.md
@@ -30,7 +30,7 @@ The library can then be loaded out of the deployed assets folder using a `script
 
 ### CDN (Content Delivery Network)
 
-Accessing the `va-report-components` library from the SAS CDN is easy. It does not require installation or
+Accessing the `va-report-components` library from the SAS Developer CDN is easy. It does not require installation or
 hosting of the library code and assets. Here is an example of loading the latest version of `va-report-components` from the CDN using an HTML `script` tag.
 
 ```html


### PR DESCRIPTION
@joylashley, this is just the doc change to reference the name change from `SAS CDN` to `SAS Developer CDN` that was previously discussed.